### PR TITLE
add non xml file in example pds4 package, upgrade pds4 example to 1.14

### DIFF
--- a/.github/workflows/stable-cicd.yaml
+++ b/.github/workflows/stable-cicd.yaml
@@ -57,6 +57,7 @@ jobs:
                 uses: NASA-PDS/roundup-action@master
                 with:
                     assembly: stable
+                    maven-stable-artifact-phases: clean,install,site,deploy
                 env:
                     ossrh_username: ${{secrets.OSSRH_USERNAME}}
                     ossrh_password: ${{secrets.OSSRH_PASSWORD}}

--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -56,6 +56,7 @@ jobs:
                 uses: NASA-PDS/roundup-action@master
                 with:
                     assembly: unstable
+                    maven-stable-artifact-phases: clean,install,site,deploy
                 env:
                     ossrh_username: ${{secrets.OSSRH_USERNAME}}
                     ossrh_password: ${{secrets.OSSRH_PASSWORD}}

--- a/pom.xml
+++ b/pom.xml
@@ -120,11 +120,11 @@ POSSIBILITY OF SUCH DAMAGE.
             <goals>
               <goal>execute</goal>
             </goals>
-            <configuration>
-              <source>${project.basedir}/src/main/script/truncate_test_data_files.gvy</source>
-            </configuration>
           </execution>
         </executions>
+        <configuration>
+           <source>${project.basedir}/src/main/script/truncate_test_data_files.gvy</source>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -103,10 +103,10 @@ POSSIBILITY OF SUCH DAMAGE.
 				<goal>wget</goal>
 			</goals>
 			<configuration>
-				<url>https://pds.nasa.gov/datastandards/documents/examples/v1/DPH_Examples_V11300.zip</url>
+				<url>https://pds.nasa.gov/datastandards/documents/examples/v1/DPH_Examples_V11400.zip</url>
 				<unpack>true</unpack>
-				<outputDirectory>${project.build.directory}</outputDirectory>
-				<md5>471c865358aae0e69216738607186ab3</md5>
+				<outputDirectory>${project.build.directory}/v11400</outputDirectory>
+				<md5>f63879feecf50fc60e083b92c3f6354b</md5>
 			</configuration>
 		</execution>
 	</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@ POSSIBILITY OF SUCH DAMAGE.
               <goal>execute</goal>
             </goals>
             <configuration>
-              <source>src/main/script/truncate_test_data_files.gvy</source>
+              <source>${project.basedir}/src/main/script/truncate_test_data_files.gvy</source>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@ POSSIBILITY OF SUCH DAMAGE.
               <goal>execute</goal>
             </goals>
             <configuration>
-              <source>${project.basedir}/src/main/script/truncate_test_data_files.gvy</source>
+              <source>src/main/script/truncate_test_data_files.gvy</source>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
   <groupId>gov.nasa.pds</groupId>
   <artifactId>pds-registry-app</artifactId>
-  <version>0.2.2</version>
+  <version>0.2.3</version>
   <packaging>jar</packaging>
 
   <name>Registry Application</name>
@@ -54,7 +54,7 @@ POSSIBILITY OF SUCH DAMAGE.
   
   <properties>
      <registry.version>4.0.2</registry.version>
-     <harvest.version>3.3.1</harvest.version>
+     <harvest.version>3.3.2</harvest.version>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
   <groupId>gov.nasa.pds</groupId>
   <artifactId>pds-registry-app</artifactId>
-  <version>0.2.3</version>
+  <version>0.2.4</version>
   <packaging>jar</packaging>
 
   <name>Registry Application</name>
@@ -54,7 +54,7 @@ POSSIBILITY OF SUCH DAMAGE.
   
   <properties>
      <registry.version>4.0.2</registry.version>
-     <harvest.version>3.3.2</harvest.version>
+     <harvest.version>3.3.3</harvest.version>
   </properties>
 
   <build>
@@ -110,7 +110,22 @@ POSSIBILITY OF SUCH DAMAGE.
 			</configuration>
 		</execution>
 	</executions>
-</plugin>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>groovy-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <source>${project.basedir}/src/main/script/truncate_test_data_files.gvy</source>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/src/main/assembly/tar-assembly.xml
+++ b/src/main/assembly/tar-assembly.xml
@@ -57,7 +57,6 @@
       <directory>target/V11400</directory>
       <outputDirectory>test</outputDirectory>
       <excludes>
-      	<exclude>**/*.img</exclude>
       	<exclude>**/Table_Character_draft1.xml</exclude>
       </excludes>
       <fileMode>664</fileMode>

--- a/src/main/assembly/tar-assembly.xml
+++ b/src/main/assembly/tar-assembly.xml
@@ -58,6 +58,7 @@
       <outputDirectory>test</outputDirectory>
       <excludes>
       	<exclude>**/*.img</exclude>
+      	<exclude>**/Table_Character_draft1.xml</exclude>
       </excludes>
       <fileMode>664</fileMode>
       <lineEnding>keep</lineEnding>

--- a/src/main/assembly/tar-assembly.xml
+++ b/src/main/assembly/tar-assembly.xml
@@ -54,11 +54,11 @@
       <lineEnding>keep</lineEnding>
     </fileSet>
     <fileSet>
-      <directory>target/V11300</directory>
+      <directory>target/V11400</directory>
       <outputDirectory>test</outputDirectory>
-      <includes>
-      	<include>**/*.xml</include>
-      </includes>
+      <excludes>
+      	<exclude>**/*.img</exclude>
+      </excludes>
       <fileMode>664</fileMode>
       <lineEnding>keep</lineEnding>
     </fileSet>

--- a/src/main/assembly/zip-assembly.xml
+++ b/src/main/assembly/zip-assembly.xml
@@ -57,7 +57,6 @@
       <directory>target/V11400</directory>
       <outputDirectory>test</outputDirectory>
       <excludes>
-      	<exclude>**/*.img</exclude>
       	<exclude>**/Table_Character_draft1.xml</exclude>
       </excludes>
       <fileMode>664</fileMode>

--- a/src/main/assembly/zip-assembly.xml
+++ b/src/main/assembly/zip-assembly.xml
@@ -58,6 +58,7 @@
       <outputDirectory>test</outputDirectory>
       <excludes>
       	<exclude>**/*.img</exclude>
+      	<exclude>**/Table_Character_draft1.xml</exclude>
       </excludes>
       <fileMode>664</fileMode>
       <lineEnding>keep</lineEnding>

--- a/src/main/assembly/zip-assembly.xml
+++ b/src/main/assembly/zip-assembly.xml
@@ -54,11 +54,11 @@
       <lineEnding>keep</lineEnding>
     </fileSet>
     <fileSet>
-      <directory>target/V11300</directory>
+      <directory>target/V11400</directory>
       <outputDirectory>test</outputDirectory>
-      <includes>
-      	<include>**/*.xml</include>
-      </includes>
+      <excludes>
+      	<exclude>**/*.img</exclude>
+      </excludes>
       <fileMode>664</fileMode>
       <lineEnding>keep</lineEnding>
     </fileSet>

--- a/src/site/xdoc/install/test.xml.vm
+++ b/src/site/xdoc/install/test.xml.vm
@@ -73,14 +73,6 @@ Specify the top level directory / bundle for Harvest to crawl for products to re
 </directories>
 ]]></source>
 
-<p>Remove also the following section, the configuration will not work on the example given below otherwise:</p>
-
-<source><![CDATA[
-<fileInfo processDataFiles="true" storeLabels="false">
-  <fileRef replacePrefix="/C:/tmp/" with="/"/>
-</fileInfo>
-]]></source>
-
 <p>See details on the harvest configuration on <a href="../operate/harvest.html">operate harvest</a></p>
 	    
 	    <p>We now need an <b>output directory</b> where the registry records will be created, for example, on unix, <i>~/tmp</i></p>

--- a/src/site/xdoc/install/test.xml.vm
+++ b/src/site/xdoc/install/test.xml.vm
@@ -80,7 +80,7 @@ Specify the top level directory / bundle for Harvest to crawl for products to re
 	    
 	    <p>At last, <b>run</b> the harvest command</p>
 <source>
-harvest -c &lt;path to the package&gt;/harvest-$context.get("harvest.version")/conf/examples/minimal.xml -o ~/tmp
+harvest -c &lt;path to the package&gt;/harvest-$context.get("harvest.version")/conf/examples/registry.xml -o ~/tmp
 </source>
     
 	</subsection>
@@ -93,7 +93,7 @@ registry-manager load-data -file ~/tmp
 	</subsection>
 	
 	<subsection name="query the registry">
-		<p>Open in your browser: <a href="http://localhost:9200/registry/_search?q=*">http://localhost:9200/registry/_search?q=*</a></p>
+		<p>Open in your browser: <a target="_blank" href="http://localhost:9200/registry/_search?q=*">http://localhost:9200/registry/_search?q=*</a></p>
 	</subsection>
 	
 	


### PR DESCRIPTION
Now the test package is in version 1.14 and all files except heavy .img file (>4Gb) are included.

Aims at solving #110 