### PR TITLE
Fixed filter products by class section in Harvest operations doc

### DIFF
--- a/src/site/xdoc/operate/harvest.xml.vm
+++ b/src/site/xdoc/operate/harvest.xml.vm
@@ -338,7 +338,7 @@ product filter in Harvest configuration file:
 &lt;harvest nodeName="PDS_SBN"&gt;
   ...
   &lt;productFilter&gt;
-    &lt;include&gt;Product_Document&lt;/include&gt;
+    &lt;includeClass&gt;Product_Document&lt;/includeClass&gt;
   &lt;/productFilter&gt;
   ...
 &lt;/harvest&gt;


### PR DESCRIPTION
**Test Instructions**
* Go to http://localhost:8080/operate/harvest.html#ProdClass (Filtering Products by Class)
* Check that example looks like this ("includeClass" instead of "include")
```
<productFilter>
    <includeClass>Product_Document</includeClass>
</productFilter>
```
